### PR TITLE
Remove 1000-char chat input limit and allow expanding textarea (fixes #2399)

### DIFF
--- a/app/frontend/src/components/QuestionInput/QuestionInput.module.css
+++ b/app/frontend/src/components/QuestionInput/QuestionInput.module.css
@@ -10,7 +10,7 @@
 
 .questionInputTextArea {
     width: 100%;
-    line-height: 2.5rem;
+    line-height: 1.5rem;
 }
 
 .questionInputButtonsContainer {
@@ -21,6 +21,13 @@
 
 @media (min-width: 992px) {
     .questionInputContainer {
-        height: 5.625rem;
+        /* Allow container to expand with growing multiline input (was fixed height) */
+        min-height: 5.625rem;
     }
+}
+
+/* Limit uncontrolled growth while still allowing larger prompts; enable scrolling inside textarea if very large */
+.questionInputTextArea textarea {
+    max-height: 20rem;
+    overflow-y: auto !important;
 }

--- a/app/frontend/src/components/QuestionInput/QuestionInput.tsx
+++ b/app/frontend/src/components/QuestionInput/QuestionInput.tsx
@@ -59,7 +59,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, init
     const onQuestionChange = (_ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         if (!newValue) {
             setQuestion("");
-        } else if (newValue.length <= 1000) {
+        } else {
             setQuestion(newValue);
         }
     };
@@ -78,6 +78,7 @@ export const QuestionInput = ({ onSend, disabled, placeholder, clearOnSend, init
                 disabled={disableRequiredAccessControl}
                 placeholder={placeholder}
                 multiline
+                autoAdjustHeight
                 resizable={false}
                 borderless
                 value={question}


### PR DESCRIPTION
## Purpose

Remove the hard-coded 1000 character limit on the chat question input and let the textarea grow (up to a visual cap) so longer prompts are supported. This addresses scenarios requiring large context prompts and fixes issue #2399.

Screenshots of entering long text- it will scroll internally in the text field once it gets fairly large:

<img width="1068" height="564" alt="Screenshot 2025-09-10 at 10 40 40 AM" src="https://github.com/user-attachments/assets/b92b8305-0c9e-4469-b457-eb27ed3f817c" />

<img width="1661" height="896" alt="Screenshot 2025-09-10 at 10 40 26 AM" src="https://github.com/user-attachments/assets/0410e08c-f51c-4f0c-928b-ea2529408768" />


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[X] No
[ ] Yes
```

## Does this require changes to learn.microsoft.com docs?

The tutorial flow / screenshots are unaffected (input just allows longer text). No doc changes required.

```
[X] No
[ ] Yes
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What was changed
- `app/frontend/src/components/QuestionInput/QuestionInput.tsx`: Removed the 1000-char guard; enabled `autoAdjustHeight`.
- `app/frontend/src/components/QuestionInput/QuestionInput.module.css`: Replaced fixed height with `min-height`, adjusted line-height, and added a `max-height` + scroll to prevent runaway growth.

## Rationale
Users reported the 1000 character constraint was limiting legitimate use cases (issue #2399). Modern chat prompts can exceed that length without harming backend processing; the UI now gracefully handles larger inputs.

## Code quality checklist

- [X] The current tests pass locally (`python -m pytest`) except for unrelated existing test flakiness (none introduced by this change).
- [ ] I added tests that prove my fix is effective or that my feature works (decided not to keep the added e2e test; it was brittle with component internals). Happy to revisit if preferred.
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines (N/A: trivial logic removal)
- [X] I ran `python -m mypy` (or ensured CI will) to check for type errors (no TS/py typing impact beyond deletion)
- [X] Pre-commit formatting hooks (ruff/black/prettier) passed on commit.

## Additional notes
An optional future enhancement could add a soft warning or token estimate for very large prompts instead of a hard cap.
