### PR TITLE
Fix multimodal image download from non-default blob container

### DIFF
--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -867,7 +867,7 @@ class Approach(ABC):
         # Download the blob using the appropriate client
         result = None
         if ".dfs.core.windows.net" in blob_url and self.user_blob_manager:
-            result = await self.user_blob_manager.download_blob(blob_path, container=container, user_oid=user_oid)
+            result = await self.user_blob_manager.download_blob(blob_path, user_oid=user_oid, container=container)
         elif self.global_blob_manager:
             result = await self.global_blob_manager.download_blob(blob_path, container=container)
 

--- a/app/backend/prepdocslib/blobmanager.py
+++ b/app/backend/prepdocslib/blobmanager.py
@@ -101,7 +101,7 @@ class BaseBlobManager:
         raise NotImplementedError("Subclasses must implement this method")
 
     async def download_blob(
-        self, blob_path: str, user_oid: Optional[str] = None
+        self, blob_path: str, user_oid: Optional[str] = None, container: Optional[str] = None
     ) -> Optional[tuple[bytes, BlobProperties]]:
         """
         Downloads a blob from Azure Storage.
@@ -110,6 +110,7 @@ class BaseBlobManager:
         Args:
             blob_path: The path to the blob in the storage
             user_oid: The user's object ID (optional)
+            container: Optional container name override (defaults to the manager's configured container)
 
         Returns:
             Optional[tuple[bytes, BlobProperties]]:
@@ -255,7 +256,7 @@ class AdlsBlobManager(BaseBlobManager):
         return unquote(file_client.url)
 
     async def download_blob(
-        self, blob_path: str, user_oid: Optional[str] = None
+        self, blob_path: str, user_oid: Optional[str] = None, container: Optional[str] = None
     ) -> Optional[tuple[bytes, BlobProperties]]:
         """
         Downloads a blob from Azure Data Lake Storage.
@@ -263,6 +264,7 @@ class AdlsBlobManager(BaseBlobManager):
         Args:
             blob_path: The path to the blob in the format {user_oid}/{document_name}/images/{image_name}
             user_oid: The user's object ID
+            container: Optional filesystem name override (ignored; this manager uses its configured filesystem)
 
         Returns:
             Optional[tuple[bytes, BlobProperties]]:
@@ -463,7 +465,7 @@ class BlobManager(BaseBlobManager):
         return blob_client.url
 
     async def download_blob(
-        self, blob_path: str, user_oid: Optional[str] = None
+        self, blob_path: str, user_oid: Optional[str] = None, container: Optional[str] = None
     ) -> Optional[tuple[bytes, BlobProperties]]:
         """
         Downloads a blob from Azure Blob Storage.
@@ -471,6 +473,7 @@ class BlobManager(BaseBlobManager):
         Args:
             blob_path: The path to the blob in the storage
             user_oid: Not used in BlobManager, but included for API compatibility
+            container: Optional container name override (defaults to self.container)
 
         Returns:
             Optional[tuple[bytes, BlobProperties]]:
@@ -484,7 +487,7 @@ class BlobManager(BaseBlobManager):
             raise ValueError(
                 "user_oid is not supported for BlobManager. Use AdlsBlobManager for user-specific operations."
             )
-        container_client = self.blob_service_client.get_container_client(self.container)
+        container_client = self.blob_service_client.get_container_client(container or self.container)
         if not await container_client.exists():
             return None
         if len(blob_path) == 0:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,7 +167,7 @@ async def test_search_image_embeddings_ignored_without_multimodal(client):
 async def test_content_file_missing_content_settings(auth_client, monkeypatch):
     blob_manager = auth_client.config[app.CONFIG_GLOBAL_BLOB_MANAGER]
 
-    async def fake_download_blob(_path):
+    async def fake_download_blob(_path, user_oid=None, container=None):
         return b"data", {}
 
     monkeypatch.setattr(blob_manager, "download_blob", fake_download_blob)


### PR DESCRIPTION
## Purpose

Fixes a bug where multimodal images were not being downloaded and displayed in the chat response.

Images are stored in a separate `images` blob container, but `download_blob_as_base64()` was not passing the container extracted from the full URL to `download_blob()`, causing the download to fail (it defaulted to the `content` container and couldn't find the blob).

This PR:
- Extracts the container name from image URLs and passes it through to the blob manager
- Adds an optional `container` parameter to `BaseBlobManager.download_blob()` and its implementations
- Adds a regression test to ensure images in non-default containers are downloaded correctly

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `ty check` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.